### PR TITLE
Build NodeJS for centos 7.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -25,11 +25,15 @@ jobs:
     steps:
       - name: Install required dependencies on CentOS
         if: startsWith(matrix.container, 'centos')
-        # Endpoint repo is required to get recent version of git so checkout action will checkout code
-        # as a local git repo instead of falling back to downloading the repo's files using the GitHub REST API
+        # 1. Endpoint repo is required to get recent version of git so checkout action will checkout code
+        #    as a local git repo instead of falling back to downloading the repo's files using the GitHub REST API
+        # 2. enable "software collections" (scl) repositories for extra packages
+        # 3. install newer gcc, etc in order to support newer C++ standards
+        # 4. python 3 is required by nodejs build
         run: |
           yum install --assumeyes https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
-          yum install --assumeyes git gcc
+          yum install -y centos-release-scl
+          yum install --assumeyes git gcc python3 devtoolset-11-gcc*
       # Work-around for https://github.com/actions/runner-images/issues/6775
       - name: Change Owner of Container Working Directory
         if: matrix.container
@@ -39,7 +43,9 @@ jobs:
       - name: Init Hermit
         run: ./bin/hermit env --raw >> $GITHUB_ENV
       - name: Build
-        run: make VERSION=${{ inputs.version }} -C pkgs/${{ inputs.package }}
+        run: |
+          if [ -f /opt/rh/devtoolset-11/enable ]; then . /opt/rh/devtoolset-11/enable; fi
+          make VERSION=${{ inputs.version }} -C pkgs/${{ inputs.package }}
       - name: Upload Release
         uses: ncipollo/release-action@v1
         with:

--- a/pkgs/build.mk
+++ b/pkgs/build.mk
@@ -18,6 +18,7 @@ DEPSDIR = $(TOPDIR)/$(NAME)/deps
 .PHONY: configure build install
 
 OUTPUT = $(NAME)-$(VERSION)-$(OS)-$(ARCH).tar.xz
+OUTPUT_DIRNAME = $(NAME)-$(VERSION)
 
 .PHONY: all
 all: $(OUTPUT)
@@ -39,8 +40,8 @@ $(OUTPUT): pkg.tar.gz
 	sandbox $(MAKE) -C build -f ../Makefile configure
 	sandbox $(MAKE) -C build -f ../Makefile build
 	sandbox $(MAKE) -C build -f ../Makefile install
-	cp -a dist $(NAME)-$(VERSION)
-	tar cfJ $(OUTPUT) $(NAME)-$(VERSION)
+	cp -a dist $(OUTPUT_DIRNAME)
+	tar cfJ $(OUTPUT) $(OUTPUT_DIRNAME)
 
 $(DEPS):
 	$(MAKE) -C ../$@

--- a/pkgs/node/Makefile
+++ b/pkgs/node/Makefile
@@ -1,0 +1,21 @@
+# the nodejs build already includes building its dependencies like v8, openssl, and statically links them.
+# however the public binaries are built against newer glibc than centos 7 has, which is something we need.
+# the build will take over 2 hours.
+VERSION ?= v18.13.0
+NAME = node
+SOURCE = https://nodejs.org/dist/${VERSION}/node-${VERSION}.tar.gz
+
+include $(shell git rev-parse --show-toplevel)/pkgs/build.mk
+
+# Override the top level directory in the output archive to match the
+# nodejs.org archives.
+OUTPUT_DIRNAME = $(NAME)-$(VERSION)-$(OS)-$(ARCH)
+
+configure:
+	./configure --prefix=/
+
+build:
+	$(MAKE)
+
+install:
+	$(MAKE) DESTDIR=$(DESTDIR) install


### PR DESCRIPTION
Why: NodeJS developers have decided not to build nodejs 18 on Centos 7 because the NodeJS 18 is to be supported all the way until 2025, but Centos 7 will be EOL before then: https://github.com/nodejs/node/issues/43246#issuecomment-1351265227

These archives are meant to match the ones on nodejs.org and act as a substitute for old platforms while some people have need for them. Building nodejs is basically just ./configure, make, make install. The build is very self contained already (e.g. it vendors in ssl, v8, ...). However there were some minor changes needed to support the build:

1. Node.js requires newer C++ compiler as well as python 3 to build. These are made available to centos 7 through the "software collections" repositories. I think they're probably useful enough to use by default.
2. To match the node.js archive structure, the OUTPUT_DIRNAME variable was introduced in the common build.mk.

I also have a question - it's not really necessary to build the darwin packages for node.js in this case, but I wasn't sure what way would best fit the repository to support "linux only package" workflow. For now I just ignored this issue.

Example build for linux: https://github.com/itsmonktastic/hermit-build/actions/runs/4088123891/jobs/7049439144
Took about 2 and a half hours.

- [ ] TODO: run some tests on the built package a bit