### PR TITLE
added build for modern version of socat

### DIFF
--- a/pkgs/socat/Makefile
+++ b/pkgs/socat/Makefile
@@ -1,0 +1,14 @@
+VERSION ?= 1.7.4.4
+NAME = socat
+SOURCE = http://www.dest-unreach.org/socat/download/socat-$(VERSION).tar.gz
+
+include $(shell git rev-parse --show-toplevel)/pkgs/build.mk
+
+configure:
+	./configure --prefix=/
+
+build:
+	$(MAKE) progs
+
+install:
+	$(MAKE) DESTDIR=$(DESTDIR) install


### PR DESCRIPTION
The version of (socat in hermit-packages)[https://github.com/cashapp/hermit-packages/blob/master/socat.hcl] pulls from an outdated third-party github mirror. This PR adds a socat build so that we can pull in a modern socat with things like vsock support