### PR TITLE
Add a workflow to generate multirelease linux binaries for mysql and …

### DIFF
--- a/.github/workflows/mysql-client.yml
+++ b/.github/workflows/mysql-client.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - mysql
 jobs:
-  mysql-client:
+  mysql-client-macos:
     strategy:
       matrix:
         binary: [mysql, mysqladmin]
@@ -28,4 +28,42 @@ jobs:
           tag: mysql-client
           allowUpdates: true
           artifacts: ${{ matrix.binary }}-${{ matrix.version }}-macos11-${{ matrix.arch }}.tar.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+  mysql-client-linux:
+    strategy:
+      matrix:
+        binary: [mysql, mysqladmin]
+        arch: [amd64]
+        version: [8.0.36]
+    name: Make a package with the mysql client binaries ${{ matrix.binary }} for ubuntu 20.04 and 22.04
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download source packagess
+        run: |
+          if [[ ${{ matrix.binary }} == "mysql" ]]; then
+            LIB="client-core"
+          elif [[ ${{ matrix.binary }} == "mysqladmin" ]]; then
+            LIB="client"
+          fi
+          curl -SsfL "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-community-${LIB}_${{ matrix.version }}-1ubuntu20.04_${{ matrix.arch }}.deb" -o client-ubuntu20.04.deb
+          curl -SsfL "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-community-${LIB}_${{ matrix.version }}-1ubuntu22.04_${{ matrix.arch }}.deb" -o client-ubuntu22.04.deb
+      - name: Unpack source packages
+        run: |
+          mkdir 20.04
+          dpkg-deb --extract client-ubuntu20.04.deb 20.04/
+          mkdir 22.04
+          dpkg-deb --extract client-ubuntu22.04.deb 22.04/
+      - name: Copy desired binaries to clean bin folder
+        run: |
+          mkdir bin
+          cp 20.04/usr/bin/${{ matrix.binary }} bin/${{ matrix.binary }}-20.04
+          cp 22.04/usr/bin/${{ matrix.binary }} bin/${{ matrix.binary }}-22.04
+      - name: Repack package
+        run: tar czf ${{ matrix.binary }}-${{ matrix.version }}-ubuntu_multirelease-${{ matrix.arch }}.tar.gz bin
+      - name: Upload Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: mysql-client
+          allowUpdates: true
+          artifacts: ${{ matrix.binary }}-${{ matrix.version }}-ubuntu_multirelease-${{ matrix.arch }}.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…mysqladmin

Currently the mysql and mysqladmin hermit packages for linux are specific to ubuntu-20.04. There is a libssl incompatibility between ubuntu 20.04 and 22.04, so the same dynamic binary cannot be used on both Ubuntu versions. Building statically linked binaries is apparently A Hard Problem. What I'm doing here is just bundling both ubuntu versions of the binaries and then we pick the appropriate one on unpack in the hermit package file.