### PR TITLE
feat: add arm64 mysqladmin

### DIFF
--- a/.github/workflows/mysql-client.yml
+++ b/.github/workflows/mysql-client.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         binary: [mysql, mysqladmin]
-        arch: [amd64]
+        arch: [amd64, arm64]
         version: [8.0.36]
     name: Make a package with the mysql client binaries ${{ matrix.binary }} for ubuntu 20.04 and 22.04
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR is to add `arm64` to the `mysqladmin` build matrix to release linux/arm64 builds.