### PR TITLE
feat: add percona mysql binary for arm64

### DIFF
--- a/.github/workflows/mysql-client.yml
+++ b/.github/workflows/mysql-client.yml
@@ -91,3 +91,38 @@ jobs:
           allowUpdates: true
           artifacts: ${{ matrix.binary }}-${{ matrix.version }}-ubuntu_multirelease-${{ matrix.arch }}.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}
+  # Use percona binaries for arm64 because linux-generic from mysql community requires
+  # dynamically linked ncurses. Hermit largely requires statically linked binaries.
+  mysql-client-linux-arm:
+    strategy:
+      matrix:
+        binary: [mysql, mysqladmin]
+        arch: [arm64]
+        version: [8.0.40-31-1]
+    name: Make a package with percona mysql client binaries ${{ matrix.binary }} for ubuntu 20.04 and 22.04
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download source packagess
+        run: |
+          curl -SsfL "https://downloads.percona.com/downloads/percona-distribution-mysql-ps/percona-distribution-mysql-ps-8.0.40/binary/debian/focal/x86_64/percona-server-client_${{ matrix.version }}.focal_${{ matrix.arch }}.deb" -o client-ubuntu20.04.deb
+          curl -SsfL "https://downloads.percona.com/downloads/percona-distribution-mysql-ps/percona-distribution-mysql-ps-8.0.40/binary/debian/jammy/x86_64/percona-server-client_${{ matrix.version }}.jammy_${{ matrix.arch }}.deb" -o client-ubuntu22.04.deb
+      - name: Unpack source packages
+        run: |
+          mkdir 20.04
+          dpkg-deb --extract client-ubuntu20.04.deb 20.04/
+          mkdir 22.04
+          dpkg-deb --extract client-ubuntu22.04.deb 22.04/
+      - name: Copy desired binaries to clean bin folder
+        run: |
+          mkdir bin
+          cp 20.04/usr/bin/${{ matrix.binary }} bin/${{ matrix.binary }}-20.04
+          cp 22.04/usr/bin/${{ matrix.binary }} bin/${{ matrix.binary }}-22.04
+      - name: Repack package
+        run: tar czf percona-${{ matrix.binary }}-${{ matrix.version }}-ubuntu_multirelease-${{ matrix.arch }}.tar.gz bin
+      - name: Upload Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: mysql-client
+          allowUpdates: true
+          artifacts: percona-${{ matrix.binary }}-${{ matrix.version }}-ubuntu_multirelease-${{ matrix.arch }}.tar.gz
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
release workflow tested: https://github.com/kevink-sq/hermit-build/releases/tag/mysql-client

contents:
```
root:/percona# ls -al
drwxr-xr-x 3 root root    4096 Feb 27 03:36 .
drwxr-xr-x 1 root root    4096 Feb 27 03:16 ..
drwxr-xr-x 2 1001  118    4096 Feb 27 03:35 bin
-rw-r--r-- 1 root root 4443589 Feb 27 03:35 percona-mysql-8.0.40-31-1-ubuntu_multirelease-arm64.tar.gz
-rw-r--r-- 1 root root 4179180 Feb 27 03:35 percona-mysqladmin-8.0.40-31-1-ubuntu_multirelease-arm64.tar.gz
root:/percona# ls -al bin
total 29472
drwxr-xr-x 2 1001  118    4096 Feb 27 03:35 .
drwxr-xr-x 3 root root    4096 Feb 27 03:36 ..
-rwxr-xr-x 1 1001  118 7725840 Feb 27 03:35 mysql-20.04
-rwxr-xr-x 1 1001  118 7717672 Feb 27 03:35 mysql-22.04
-rwxr-xr-x 1 1001  118 7362928 Feb 27 03:35 mysqladmin-20.04
-rwxr-xr-x 1 1001  118 7354760 Feb 27 03:35 mysqladmin-22.04
```