### PR TITLE
fix: allow updating releases without replacing artifacts

### DIFF
--- a/.github/workflows/mysql-client.yml
+++ b/.github/workflows/mysql-client.yml
@@ -27,7 +27,8 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: mysql-client
-          skipIfReleaseExists: true
+          allowUpdates: true
+          replacesArtifacts: false
           artifacts: ${{ matrix.binary }}-${{ matrix.version }}-macos11-${{ matrix.arch }}.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}
   mysql-client-macos14:
@@ -51,7 +52,8 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: mysql-client
-          skipIfReleaseExists: true
+          allowUpdates: true
+          replacesArtifacts: false
           artifacts: ${{ matrix.binary }}-${{ matrix.version }}-macos14-${{ matrix.arch }}.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}
   mysql-client-linux:
@@ -89,7 +91,8 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: mysql-client
-          skipIfReleaseExists: true
+          allowUpdates: true
+          replacesArtifacts: false
           artifacts: ${{ matrix.binary }}-${{ matrix.version }}-ubuntu_multirelease-${{ matrix.arch }}.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}
   mysql-client-linux-arm:


### PR DESCRIPTION
Passing run: https://github.com/kevink-sq/hermit-build/actions/runs/13801473403

![Screenshot 2025-03-11 at 6 03 03 PM](https://github.com/user-attachments/assets/99e92822-23cd-42ed-82af-94c14477d9c4)
