### PR TITLE
feat: update graphviz version to the latest 12.2.1

### DIFF
--- a/pkgs/graphviz/Makefile
+++ b/pkgs/graphviz/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 7.1.0
+VERSION ?= 12.2.1
 NAME = graphviz
 SOURCE = https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/$(VERSION)/graphviz-$(VERSION).tar.xz
 


### PR DESCRIPTION
the latest version from source: https://gitlab.com/graphviz/graphviz/-/releases is 12.2.1. v7.1.0 is quite outdated and lacks features such as support for PNG format.