### PR TITLE
Ensure that the existing artifacts do not get updated

### DIFF
--- a/.github/workflows/gotip.yml
+++ b/.github/workflows/gotip.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           tag: gotip
           allowUpdates: true
-          replacesArtifacts: false
+          replacesArtifacts: true  # Safe to replace; gotip has no checksum
           artifacts: "gotip/go-*.tbz"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gotip.yml
+++ b/.github/workflows/gotip.yml
@@ -27,5 +27,6 @@ jobs:
         with:
           tag: gotip
           allowUpdates: true
+          replacesArtifacts: false
           artifacts: "gotip/go-*.tbz"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpg.yml
+++ b/.github/workflows/gpg.yml
@@ -20,5 +20,6 @@ jobs:
         with:
           tag: gpg
           allowUpdates: true
+          replacesArtifacts: false
           artifacts: "gpg/gnupg-*.tar.bz2"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -31,5 +31,6 @@ jobs:
         with:
           tag: ${{ inputs.package }}-${{ steps.build.outputs.VERSION }}
           allowUpdates: true
+          replacesArtifacts: false
           artifacts: "pkgs/${{ inputs.package }}/${{ inputs.package }}-${{ steps.build.outputs.VERSION }}-*.tar.xz"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/protoc-gen-swift.yml
+++ b/.github/workflows/protoc-gen-swift.yml
@@ -39,5 +39,6 @@ jobs:
           name: protoc-gen-swift ${{ inputs.version }}
           tag: protoc-gen-swift-${{ inputs.version }}
           allowUpdates: true
+          replacesArtifacts: false
           artifacts: protoc-gen-swift-${{ inputs.version }}-macos.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To prevent checksum mismatches caused when a new artifact with the same version replaces an older one.

We did this for mysql pipeline https://github.com/cashapp/hermit-build/commit/d02ececefd3a6319db2acad91afa792cd641988e but this should apply to other pipelines too