### PR TITLE
Add deps required for new graphviz version

### DIFF
--- a/pkgs/graphviz/Makefile
+++ b/pkgs/graphviz/Makefile
@@ -6,7 +6,7 @@ DEPS = libsodium libargon2
 include $(shell git rev-parse --show-toplevel)/pkgs/build.mk
 
 configure:
-	./configure --prefix=/
+	./configure --prefix=/ --enable-static=yes --disable-shared
 
 build:
 	$(MAKE)

--- a/pkgs/graphviz/Makefile
+++ b/pkgs/graphviz/Makefile
@@ -1,6 +1,7 @@
 VERSION ?= 12.2.1
 NAME = graphviz
 SOURCE = https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/$(VERSION)/graphviz-$(VERSION).tar.xz
+DEPS = libsodium libargon2
 
 include $(shell git rev-parse --show-toplevel)/pkgs/build.mk
 

--- a/pkgs/libargon2/Makefile
+++ b/pkgs/libargon2/Makefile
@@ -1,11 +1,8 @@
 VERSION ?= 20190702
-NAME = libsodium
+NAME = libargon2
 SOURCE = https://github.com/P-H-C/phc-winner-argon2/archive/refs/tags/$(VERSION).tar.gz
 
 include $(shell git rev-parse --show-toplevel)/pkgs/build.mk
-
-configure:
-	./configure --prefix=/ --disable-shared
 
 build:
 	$(MAKE)

--- a/pkgs/libargon2/Makefile
+++ b/pkgs/libargon2/Makefile
@@ -1,0 +1,14 @@
+VERSION ?= 20190702
+NAME = libsodium
+SOURCE = https://github.com/P-H-C/phc-winner-argon2/archive/refs/tags/$(VERSION).tar.gz
+
+include $(shell git rev-parse --show-toplevel)/pkgs/build.mk
+
+configure:
+	./configure --prefix=/ --disable-shared
+
+build:
+	$(MAKE)
+
+install:
+	$(MAKE) DESTDIR=$(DESTDIR) install

--- a/pkgs/libsodium/Makefile
+++ b/pkgs/libsodium/Makefile
@@ -1,0 +1,14 @@
+VERSION ?= 1.0.20
+NAME = libsodium
+SOURCE = https://download.libsodium.org/libsodium/releases/libsodium-$(VERSION)-stable.tar.gz
+
+include $(shell git rev-parse --show-toplevel)/pkgs/build.mk
+
+configure:
+	./configure --prefix=/ --disable-shared
+
+build:
+	$(MAKE)
+
+install:
+	$(MAKE) DESTDIR=$(DESTDIR) install


### PR DESCRIPTION
[`graphviz` build](https://github.com/cashapp/hermit-build/actions/runs/14767615261/job/41462018942) failed with:

```
/usr/bin/ld: cannot find -lsodium: No such file or directory
/usr/bin/ld: cannot find -largon2: No such file or directory
```

Adding `libsodium` and `libargon2` packages and `DEPS` for them in `graphviz`.