### PR TITLE
Update macos runner from deprecated macos-12 to macos-13

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -13,7 +13,7 @@ jobs:
     container: ${{ matrix.container }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04, macos-13]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
The macos-12 runner [has been deprecated](https://github.com/actions/runner-images/issues/10721) and were seeing an [issue](https://github.com/cashapp/hermit-build/actions/runs/14769362879/job/41466708188) with getting macos jobs to be picked up.

This change updates the runner on the `pkg` workflow to use `macos-13` instead.