### PR TITLE
Add macos arm64 runner for pkg workflow

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -12,7 +12,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        # runner architecture defined here -> https://github.com/actions/runner-images
+        os: [
+          ubuntu-22.04,   # linux-amd64
+          macos-13,       # darwin-amd64
+          macos-13-xlarge # darwin-arm64
+        ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Adding `macos-13-xlarge` runner to get a `darwin-arm64` build from the `pkg` workflow (as per the runner list [here](https://github.com/actions/runner-images?tab=readme-ov-file#available-images)).