### PR TITLE
Rename dot_static to dot when packaging graphviz

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -14,9 +14,10 @@ jobs:
       matrix:
         # runner architecture defined here -> https://github.com/actions/runner-images
         os: [
-          ubuntu-22.04,   # linux-amd64
-          macos-13,       # darwin-amd64
-          macos-13-xlarge # darwin-arm64
+          ubuntu-22.04,     # linux-amd64
+          ubuntu-22.04-arm, # linux-arm64
+          macos-13,         # darwin-amd64
+          macos-13-xlarge   # darwin-arm64
         ]
     steps:
       - name: Checkout code

--- a/pkgs/graphviz/Makefile
+++ b/pkgs/graphviz/Makefile
@@ -13,3 +13,4 @@ build:
 
 install:
 	$(MAKE) DESTDIR=$(DESTDIR) install
+	mv $(DESTDIR)/bin/dot_static $(DESTDIR)/bin/dot

--- a/sandbox.sb
+++ b/sandbox.sb
@@ -14,6 +14,7 @@
 
 (allow file-read*)
 (deny file-read*
+  (subpath "/opt/")
   (subpath "/usr/local/")
 )
 
@@ -28,6 +29,7 @@
 
 (allow process-exec*)
 (deny process-exec*
+  (subpath "/opt/")
   (subpath "/usr/local/")
 )
 

--- a/sandbox.sb
+++ b/sandbox.sb
@@ -14,7 +14,6 @@
 
 (allow file-read*)
 (deny file-read*
-  (subpath "/opt/")
   (subpath "/usr/local/")
 )
 
@@ -29,7 +28,6 @@
 
 (allow process-exec*)
 (deny process-exec*
-  (subpath "/opt/")
   (subpath "/usr/local/")
 )
 


### PR DESCRIPTION
New version [failed to update](https://github.com/cashapp/hermit-packages/actions/runs/14771039016/job/41471011729?pr=612#step:4:128) in `hermit-packages` because the `dot` executable comes out at `dot_static` instead.

This change renames it to `dot` before packaging.

We're also adding a `linux-arm64` runner as part of this change.