### PR TITLE
feat: libusb

### DIFF
--- a/pkgs/libusb/Makefile
+++ b/pkgs/libusb/Makefile
@@ -1,0 +1,14 @@
+VERSION ?= 1.0.29
+NAME = libusb
+SOURCE = https://github.com/libusb/libusb/releases/download/v${VERSION}/libusb-${VERSION}.tar.bz2
+
+include $(shell git rev-parse --show-toplevel)/pkgs/build.mk
+
+configure:
+	./configure --enable-static --disable-shared --prefix=/
+
+build:
+	make -j8
+
+install:
+	make DESTDIR=$(DESTDIR) install


### PR DESCRIPTION
```
pkgs/libusb/libusb-1.0.29/include/libusb-1.0/libusb.h
pkgs/libusb/libusb-1.0.29/lib/libusb-1.0.a
pkgs/libusb/libusb-1.0.29/lib/libusb-1.0.la
pkgs/libusb/libusb-1.0.29/lib/pkgconfig/libusb-1.0.pc
```

Still needs some work:

- It needs a script included for Hermit to be able to install it
- The Hermit package needs to post-process the pkg-config file to change the prefix
- Untested on Linux
- Possibly some more flags/different flags for Linux